### PR TITLE
Task 7 (Authorization)

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,12 @@
+# package directories
+node_modules
+coverage
+
+# Serverless directories
+.serverless
+
+# esbuild directories
+.esbuild
+
+# environmental variables
+.env

--- a/authorization-service/serverless.ts
+++ b/authorization-service/serverless.ts
@@ -1,0 +1,41 @@
+import type { AWS } from '@serverless/typescript';
+
+const serverlessConfiguration: AWS = {
+  service: 'authorization-service',
+  frameworkVersion: '3',
+  plugins: ['serverless-esbuild', 'serverless-dotenv-plugin'],
+  useDotenv: true,
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs14.x',
+    region: 'eu-west-1',
+    apiGateway: {
+      minimumCompressionSize: 1024,
+      shouldStartNameWithService: true,
+    },
+    environment: {
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+      NODE_OPTIONS: '--enable-source-maps --stack-trace-limit=1000',
+    }
+  },
+  functions: {
+    basicAuthorizer: {
+      handler: 'src/functions/basicAuthorizer/index.handler'
+    },
+  },
+  package: { individually: true },
+  custom: {
+    esbuild: {
+      bundle: true,
+      minify: false,
+      sourcemap: true,
+      exclude: ['aws-sdk'],
+      target: 'node14',
+      define: { 'require.resolve': undefined },
+      platform: 'node',
+      concurrency: 10,
+    },
+  },
+};
+
+module.exports = serverlessConfiguration;

--- a/authorization-service/src/functions/basicAuthorizer/index.ts
+++ b/authorization-service/src/functions/basicAuthorizer/index.ts
@@ -1,0 +1,43 @@
+import { UnauthorizedError } from "@utils/errors";
+import { APIGatewayIAMAuthorizerResult } from "aws-lambda";
+
+export const handler =  async (event, _context, callback) => {
+  try {
+    if (event.type !== 'TOKEN') {
+      throw new UnauthorizedError('Unauthorized');
+    }
+  
+    const authorizationHeaderSplitted = event.authorizationToken?.split(" ");
+    const encodedCredentials =
+      authorizationHeaderSplitted[0] === "Basic" ? authorizationHeaderSplitted[1] : null;
+  
+    if (!encodedCredentials) {
+      throw new UnauthorizedError('Authorization header is not provided');
+    }
+  
+    const [username, password] = Buffer.from(encodedCredentials, 'base64').toString().split(':');
+  
+    const storedPassword = process.env[username];
+    const isValid = storedPassword === password;
+    if (!storedPassword || !isValid) {
+      callback(null, getPolicy(encodedCredentials, event.methodArn, 'Deny'));
+    }
+  
+    callback(null, getPolicy(encodedCredentials, event.methodArn));
+  } catch (error) {
+    callback(error.message);
+  }
+};
+
+const getPolicy = (principalId, resource, effect = 'Allow'): APIGatewayIAMAuthorizerResult => ({
+  principalId,
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Action: ["execute-api:Invoke"],
+        Effect: effect,
+        Resource: resource
+      }]
+  }
+});

--- a/authorization-service/src/utils/errors/index.ts
+++ b/authorization-service/src/utils/errors/index.ts
@@ -1,0 +1,43 @@
+import { Status } from '../http/status'
+
+export class BaseError extends Error {
+    status: Status;
+    constructor(message: string) {
+        super(message);
+        this.name = 'InternalError';
+        this.status = Status.INTERNAL_SERVER_ERROR;
+    }
+}
+
+export class NotFoundError extends BaseError {
+    constructor(message: string) {
+        super(message);
+        this.name = 'NotFoundError';
+        this.status = Status.NOT_FOUND;
+    }
+}
+
+export class BadRequestError extends BaseError {
+    constructor(message: string) {
+        super(message);
+        this.name = 'BadRequestError';
+        this.status = Status.BAD_REQUEST;
+    }
+}
+
+export class UnauthorizedError extends BaseError {
+    constructor(message: string) {
+        super(message);
+        this.name = 'UnauthorizedError';
+        this.status = Status.UNAUTHORIZED;
+    }
+}
+
+export class ForbiddenError extends BaseError {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ForbiddenError';
+        this.status = Status.FORBIDDEN;
+    }
+}
+

--- a/authorization-service/src/utils/http/status.ts
+++ b/authorization-service/src/utils/http/status.ts
@@ -1,0 +1,7 @@
+export enum Status {
+    BAD_REQUEST = 400,
+    UNAUTHORIZED = 401,
+    FORBIDDEN = 403,
+    NOT_FOUND = 404,
+    INTERNAL_SERVER_ERROR = 500
+}

--- a/authorization-service/tsconfig.json
+++ b/authorization-service/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.paths.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "removeComments": true,
+    "sourceMap": true,
+    "target": "ES2020",
+    "outDir": "lib"
+  },
+  "include": ["src/**/*.ts", "serverless.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ],
+  "ts-node": {
+    "require": ["tsconfig-paths/register"]
+  },
+  "esModuleInterop": true
+}

--- a/authorization-service/tsconfig.paths.json
+++ b/authorization-service/tsconfig.paths.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@functions/*": ["src/functions/*"],
+      "@utils/*": ["src/utils/*"],
+      "@errors": ["src/utils/errors/index.ts"],
+      "@errors/*": ["src/utils/errors/*"],
+    }
+  }
+}

--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -40,6 +40,13 @@ const serverlessConfiguration: AWS = {
           {
             Effect: "Allow",
             Action: [
+              "lambda:InvokeFunction"
+            ],
+            Resource: ['arn:aws:lambda:eu-west-1:485082172910:function:authorization-service-dev-basicAuthorizer'],
+          },
+          {
+            Effect: "Allow",
+            Action: [
               "sqs:*"
             ],
             Resource: [{
@@ -84,6 +91,16 @@ const serverlessConfiguration: AWS = {
                 }
               }
             },
+            cors: {
+              headers: ['Authorization'],
+            },
+            authorizer: {
+              arn: 'arn:aws:lambda:eu-west-1:485082172910:function:authorization-service-dev-basicAuthorizer',
+              identitySource: 'method.request.header.Authorization',
+              resultTtlInSeconds: 0,
+              type: 'token',
+              managedExternally: false
+            }
           }
         },
       ]

--- a/import-service/src/utils/formatResponse.ts
+++ b/import-service/src/utils/formatResponse.ts
@@ -7,6 +7,7 @@ const formatJsonApiResponse = <T>(response: T | Error, statusCode = 200) => {
         headers: {
             'Access-Control-Allow-Origin': '*',
             'Access-Control-Allow-Credentials': true,
+            'Access-Control-Allow-Headers': 'Authorization'
         },
         statusCode,
         body: JSON.stringify(response),


### PR DESCRIPTION
1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
3 - Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda works only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response has 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
5 - Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser. [FE changes](https://github.com/MedvedevaM/shop-react-redux-cloudfront/pull/4)

Link for testing https://x5u2bz58w4.execute-api.eu-west-1.amazonaws.com/dev/import?name=products.csv
[Cloud Front](https://d3399abblz93m6.cloudfront.net/)

**Total score: 5**


